### PR TITLE
Fix to get rviz configuration argument

### DIFF
--- a/robot_moveit_config/launch/moveit_rviz.launch
+++ b/robot_moveit_config/launch/moveit_rviz.launch
@@ -5,11 +5,11 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="rviz_config" default="" />
-  <arg     if="$(eval rviz_config=='')" name="command_args" value="" />
+  <arg     if="$(eval rviz_config=='')" name="command_args" value="-d $(find pick_place)/src/default.rviz" />
   <arg unless="$(eval rviz_config=='')" name="command_args" value="-d $(arg rviz_config)" />
 
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
-        args="-d $(find pick_place)/src/default.rviz" output="screen">
+        args="$(arg command_args)" output="screen">
   </node>
 
 </launch>


### PR DESCRIPTION
This PR enables to get other rviz configuration arguments.
default.rviz in pick_place package will be opened by default.

Example usage:
https://github.com/daeunSong/dual_ur_robotiq/blob/7beb4adc55899810c77db52350faaff127abb07f/drawing/launch/drawing.launch#L3-L5